### PR TITLE
Update action.yml to use node 20 instead of node 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Updated
+### Changed
 
+- Updated the `action.yml` to run the action on node 20 instead of 16.
 - Updated readme to show correct version usage with @v0
 
 ## [0.4.0] - 2023-11-06

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
This pull request updates the `action.yml` file to use node 20 instead of node 16. This change ensures that the action runs on the latest version of Node.js.