### PR TITLE
Update yarn install command to ignore engines and log errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the `yarn` install command to ignore engines with the `--ignore-engines` flag.
+- Updated the `yarn` install command to log errors if there are any issues with the installation.
+
 ## [0.5.0] - 2024-02-27
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -14535,9 +14535,15 @@ const blockedLicenses = core.getMultilineInput("blockedLicenses");
 const continueOnBlockedFound = core.getBooleanInput("continueOnBlockedFound");
 const processNpm = (projectPath) => __awaiter(void 0, void 0, void 0, function* () {
     core.info(`Starting processNpm for: ${projectPath}`);
-    yield exec.exec("yarn", [""], {
-        silent: true,
-    });
+    try {
+        yield exec.exec("yarn", ["--ignore-engines"], {
+            silent: true,
+        });
+    }
+    catch (error) {
+        core.error(`Error running yarn: ${error}`);
+        throw error;
+    }
     // create detailed report
     const { stdout: licenseReportDetailed } = yield exec.getExecOutput("npx", ["license-compliance@2", "--production", "--format", "json", "--report", "detailed"], { silent: true });
     const tableData = JSON.parse(licenseReportDetailed).map(({ name, version, license, repository }) => {

--- a/src/npmlicensecheck.ts
+++ b/src/npmlicensecheck.ts
@@ -14,9 +14,14 @@ interface PackageEntry {
 const processNpm = async (projectPath: string): Promise<string> => {
   core.info(`Starting processNpm for: ${projectPath}`);
 
-  await exec.exec("yarn", [""], {
-    silent: true,
-  });
+  try {
+    await exec.exec("yarn", ["--ignore-engines"], {
+      silent: true,
+    });
+  } catch (error) {
+    core.error(`Error running yarn: ${error}`);
+    throw error;
+  }
 
   // create detailed report
   const { stdout: licenseReportDetailed } = await exec.getExecOutput(


### PR DESCRIPTION
This pull request updates the `yarn` install command to improve reliability and error handling during package installation. The changes include adding the `--ignore-engines` flag to bypass engine checks and implementing error logging to capture installation issues.

### Improvements to `yarn` command:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R14): Documented updates to the `yarn` install command, including the addition of the `--ignore-engines` flag and enhanced error logging during installation.
* [`src/npmlicensecheck.ts`](diffhunk://#diff-a8f3d9dc183979c99c1da1f5ac644e1df2c8cfa99233cac4e95c91f04a376daaL17-R24): Modified the `yarn` command execution to include the `--ignore-engines` flag and added a `try-catch` block to log errors and rethrow them for better error handling.